### PR TITLE
fix: bump jackson-databind to 2.21.0 in junit-sample

### DIFF
--- a/junit-sample/pom.xml
+++ b/junit-sample/pom.xml
@@ -92,7 +92,7 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.18.2</version>
+      <version>2.21.0</version>
     </dependency>
 
   <!-- testing -->


### PR DESCRIPTION
Aligns the junit-sample's direct `jackson-databind` dependency with the Jackson version current Imposter releases are built against, so the example's runtime classpath uses a single, consistent Jackson.

## Summary
- Bump `jackson-databind` from 2.18.2 to 2.21.0 in `junit-sample/pom.xml`

## Implementation details
Imposter publishes against Jackson 2.21.0. The sample's direct `jackson-databind` declaration was the nearest match in Maven's nearest-wins resolution, so it kept pulling `jackson-annotations` 2.18 onto the test classpath. That conflicted with `jackson-module-kotlin` 2.21 (which calls `JsonProperty.isRequired()` expecting the new `OptBoolean` return type introduced in 2.19+), producing `NoSuchMethodError` at engine startup and breaking the `Examples` job in imposter-jvm-engine's CI. Bumping the sample's direct version to 2.21.0 lets nearest-wins agree with Imposter on a single Jackson version.

The example's `PetService.java` uses `ObjectMapper` from `src/main/java`, so the dependency itself must stay (compile-scope) — only the version needs to track the engine.