### PR TITLE
ci: add JUnit sample test workflow

### DIFF
--- a/.github/workflows/junit-sample.yaml
+++ b/.github/workflows/junit-sample.yaml
@@ -1,0 +1,53 @@
+name: JUnit Sample
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      checks: write
+    steps:
+      - name: Checkout examples
+        uses: actions/checkout@v6
+
+      - name: Checkout imposter-jvm-engine
+        uses: actions/checkout@v6
+        with:
+          repository: 'imposter-project/imposter-jvm-engine'
+          path: 'imposter-jvm-engine'
+
+      - name: Setup Java
+        uses: actions/setup-java@v5
+        with:
+          java-version: 11
+          distribution: 'temurin'
+          cache: 'maven'
+
+      - name: Set up build environment
+        run: |
+          # Disable gradle daemon
+          mkdir -p ~/.gradle
+          echo "org.gradle.daemon=false" >> ~/.gradle/gradle.properties
+
+      - name: Publish imposter to local Maven repository
+        id: publish-maven-local
+        working-directory: ./imposter-jvm-engine
+        run: |
+          ./gradlew publishToMavenLocal --stacktrace -xtest
+          echo "PUBLISHED_VERSION=$( cat gradle.properties | grep projectVersion= | cut -c16- )" >> $GITHUB_OUTPUT
+
+      - name: Test JUnit example project
+        working-directory: ./junit-sample
+        run: ./mvnw test -Dimposter.version=${{ steps.publish-maven-local.outputs.PUBLISHED_VERSION }}
+
+      - name: Publish unit test results
+        if: always()
+        uses: EnricoMi/publish-unit-test-result-action@v2
+        with:
+          files: "**/surefire-reports/**/*.xml"
+          comment_mode: off

--- a/junit-sample/pom.xml
+++ b/junit-sample/pom.xml
@@ -92,7 +92,7 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.18.2</version>
+      <version>2.21.0</version>
     </dependency>
 
   <!-- testing -->


### PR DESCRIPTION
Adds a GitHub Actions workflow that runs the `junit-sample` integration test against `imposter-jvm-engine`'s `main`, mirroring the check that lives in the engine repo today.

## Summary
- Add `.github/workflows/junit-sample.yaml`: checks out this repo and `imposter-project/imposter-jvm-engine`, publishes the engine to a local Maven repo (`./gradlew publishToMavenLocal -xtest`), then runs `./mvnw test` against the locally-published SNAPSHOT
- Triggers: push to `main`, pull requests, and manual `workflow_dispatch`
- Publishes JUnit results via `EnricoMi/publish-unit-test-result-action` so failures surface as checks

## Implementation details
Mirrors the existing `Examples` job in `imposter-jvm-engine`. Having the check here lets contributions to the examples repo block on the same combination before merge — previously a breaking change to a sample pom (like the Jackson version drift fixed in #5) would only surface on the engine's next CI run.
